### PR TITLE
readme: state that project is no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Fantasy Identities
 
-This library implements purely functional, monadic identities.
+This project is no longer developed or maintained.
+Consider [sanctuary-identity][1] as a replacement.
 
-## Fantasy Land Compatible
 
-[
-  ![](https://raw.github.com/fantasyland/fantasy-land/master/logo.png)
-](https://github.com/fantasyland/fantasy-land)
+[1]: https://github.com/sanctuary-js/sanctuary-identity


### PR DESCRIPTION
I hope this pull request doesn't seem passive-aggressive.

Fantasy Land is a wonderful specification, and fantasy-laws is very useful for testing the lawfulness of implementations. The various ADT libraries in the @fantasyland account, though, have not been well maintained over the years. This project, for example, has not been updated to use prefixed methods, a change that was made almost two years ago. In my view the presence of several outdated projects in the @fantasyland account detracts from a central tenet of Fantasy Land: seamless interoperability.
